### PR TITLE
Begin work toward supporting linux, darwin and windows builds

### DIFF
--- a/holochain-overlay/default.nix
+++ b/holochain-overlay/default.nix
@@ -23,7 +23,6 @@ self: super: {
       then archMap.${system} // { inherit version; }
       else throw "Unsupported system: ${system}";
 
-
   holochain_0-1-8 = super.callPackage ./holochain/default.nix { version = "0.1.8"; sha256 = "HVJ6SItgOj2fkGAOsbzS5d/+4yau+xIyTxl/59Ela8s="; };
 
   holochain_0-1-x = self.holochain_0-1-8;
@@ -72,9 +71,26 @@ self: super: {
   holochain_0-4-0-dev-10 = super.callPackage ./holochain/default.nix { version = "0.4.0-dev.10"; sha256 = "POl+Zu3QhI6LB3PN1bUVVKo1A0FiLSzCc8gX9Jwb/7M="; };
   holochain_0-4-0-dev-11 = super.callPackage ./holochain/default.nix { version = "0.4.0-dev.11"; sha256 = "ncS9Drru8qNcAt/KmW18CAnAiHYfwdcaiE2qAOseNIc="; };
   holochain_0-4-0-dev-12 = super.callPackage ./holochain/default.nix { version = "0.4.0-dev.12"; sha256 = "jQtswjO7d1nzaexr09ygmKGscXj9IRFJqXFQgnqFqPc="; };
-  holochain_0-4-0-dev-13 = super.callPackage ./holochain/default.nix { version = "0.4.0-dev.13"; sha256 = "Ub7Mj+XM50EYIWJonn3UD++dfkGUUssA8LxJTKuDbGs="; };
+  holochain_0-4-0-dev-13 = super.callPackage ./holochain/default.nix (
+    self.selectArchConfig {
+      version = "0.4.0-dev.13";
+      linux_x64 = "Ub7Mj+XM50EYIWJonn3UD++dfkGUUssA8LxJTKuDbGs=";
+      darwin_x64 = "Z5OmPR1/TXFW4NuRjGCEby4WMngW0ho/EdLXSwavs4I=";
+      darwin_aarch64 = "KCzCf+vqMdAWk4GylCIp8ot13xN+61grxsje3DqL53A=";
+      windows_x64 = "yeoJ40XqQ6oP8G9xKBNL13WGbc9sS9VpMCNk2rgAmcY=";
+    }
+  );
+  holochain_0-4-0-dev-14 = super.callPackage ./holochain/default.nix (
+    self.selectArchConfig {
+      version = "0.4.0-dev.14";
+      linux_x64 = "ckT0+aKOiGmgAlreS/cmMPu8pJyymiiybOwAgaZI/tI=";
+      darwin_x64 = "RafQ+SuQ8FpIqNpRcE0LFW9+RlQMXIbC8R0cYe3+j2Y=";
+      darwin_aarch64 = "8EXyGuFjS5kBycELDLpFIgbmcEOu2TDrz4738SLKJVM=";
+      windows_x64 = "c4Tdv/6iUrPlU7SxdxI65Op7w7rb4bLeZkKOv/ZaUZ4=";
+    }
+  );
 
-  holochain_0-4-x = self.holochain_0-4-0-dev-13;
+  holochain_0-4-x = self.holochain_0-4-0-dev-14;
   holochain_0-4 = self.createSymlink self.holochain_0-4-x "holochain-0.4";
 
   holochain_0-x = self.holochain_0-3-x;
@@ -87,7 +103,15 @@ self: super: {
   lair-keystore_0-4-2 = super.callPackage ./lair-keystore/default.nix { version = "0.4.2"; sha256 = "Q4AvHOvW5800eFcj8Di+9CUflMBELl83BASEdrNLB0A="; };
   lair-keystore_0-4-3 = super.callPackage ./lair-keystore/default.nix { version = "0.4.3"; sha256 = "R1H4HA5LL9axFe/bFJ9hq2iX7BOOug2vdWqyKFbyGO8="; };
   lair-keystore_0-4-4 = super.callPackage ./lair-keystore/default.nix { version = "0.4.4"; sha256 = "KVx0P/KmxVag0fboriAzoBtgeEW8D0wzhZv4WTEHpCo="; };
-  lair-keystore_0-4-5 = super.callPackage ./lair-keystore/default.nix { version = "0.4.5"; sha256 = "Z7Wo0GV1/BTGKV/sBc0tzTON52oFHOrG3XsD6SHuF2I="; };
+  lair-keystore_0-4-5 = super.callPackage ./lair-keystore/default.nix (
+    self.selectArchConfig {
+      version = "0.4.5";
+      linux_x64 = "Z7Wo0GV1/BTGKV/sBc0tzTON52oFHOrG3XsD6SHuF2I=";
+      darwin_x64 = "YMgRBLuqN+aXSaf1OwedBkFNB0GKFRSjxnZQPOKGHEo=";
+      darwin_aarch64 = "9uQnVXJx0TqzK92GcvBAi4skgReECtxkyFjVWmrlZYM=";
+      windows_x64 = "d8tOUamBYEhSCjApN2AhRIOgo3KrVUrUlpVRZ+YAnJk=";
+    }
+  );
 
   lair-keystore_0-4-x = self.lair-keystore_0-4-5;
   lair-keystore_0-4 = self.createSymlink self.lair-keystore_0-4-x "lair-keystore-0.4";
@@ -123,21 +147,26 @@ self: super: {
   hc_0-4-0-dev-10 = super.callPackage ./hc/default.nix { version = "0.4.0-dev.10"; sha256 = "iFPxtUYPw3qw6DcQNd2kUPko2bWqKHqZe7eQvYkAukg="; };
   hc_0-4-0-dev-11 = super.callPackage ./hc/default.nix { version = "0.4.0-dev.11"; sha256 = "7AWGvEYRA7MuEzXbCbxIY3HSDFJmxiq2wMUqoXDruaM="; };
   hc_0-4-0-dev-12 = super.callPackage ./hc/default.nix { version = "0.4.0-dev.12"; sha256 = "iWrApgqni5S+tI9SpPxbIJw5EdIQrzX/xM+50jOk/4k="; };
-  #hc_0-4-0-dev-13 = super.callPackage ./hc/default.nix { version = "0.4.0-dev.13"; sha256 = "/OdBIq8hhePmnQ6FXbt4jD6+4Pm+KIfPHCfd1mgAF8s="; };
-
-
-  # Define packages for each version
   hc_0-4-0-dev-13 = super.callPackage ./hc/default.nix (
     self.selectArchConfig {
       version = "0.4.0-dev.13";
       linux_x64 = "/OdBIq8hhePmnQ6FXbt4jD6+4Pm+KIfPHCfd1mgAF8s=";
       darwin_x64 = "iUcUdQak6hCyBzvH7cHvHxuVhs6b14KLQkNnaNfe6mE=";
-      darwin_aarch64 = "0000000000000000000000000000000000000000000=";
-      windows_x64 = "0000000000000000000000000000000000000000000=";
+      darwin_aarch64 = "gwzLxNimwM1pgG/+jetX6QLfZj0pKYPh3X636H0gB8w=";
+      windows_x64 = "d3RMBeNpkxKaGz0KTHxfrNmlyB1H0ZAeW4Li2U9nfcI=";
+    }
+  );
+  hc_0-4-0-dev-14 = super.callPackage ./hc/default.nix (
+    self.selectArchConfig {
+      version = "0.4.0-dev.14";
+      linux_x64 = "1HlzhtFoU0MrVXnXgZbtvCoQp+oPE1c6yMPUCrliD5g=";
+      darwin_x64 = "1PyX6nJlxQ7kT9QDNzNGkBI4Rf0wmXZF5RBUjgcGM4o=";
+      darwin_aarch64 = "bmmqphb5x04x/OR91yeONzQ6fMiRd2317AGuHpou1n0=";
+      windows_x64 = "FbN+4e8EGdXUdDtpameBN8iTKmyS6ajBx3ZTIBzsF+g=";
     }
   );
 
-  hc_0-4-x = self.hc_0-4-0-dev-13;
+  hc_0-4-x = self.hc_0-4-0-dev-14;
   hc_0-4 = self.createSymlink self.hc_0-4-x "hc-0.4";
 
   hc_0-x = self.hc_0-3-x;

--- a/holochain-overlay/default.nix
+++ b/holochain-overlay/default.nix
@@ -55,6 +55,7 @@ self: super: {
   holochain_0-3-1-rc-1 = super.callPackage ./holochain/default.nix { version = "0.3.1-rc.1"; sha256 = "/j4wxFh8qR2b5CwXp3eLxoJP3t1RB4b4Z+IwMPesW3Y="; };
   holochain_0-3-1-rc-2 = super.callPackage ./holochain/default.nix { version = "0.3.1-rc.2"; sha256 = "SD7nMtyhBZbpIkD7TVN5utM0tGGegwiyhi8MuX3Os0w="; };
   holochain_0-3-1 = super.callPackage ./holochain/default.nix { version = "0.3.1"; sha256 = "AkNc8ex/a4Uo8jHXN3M8wFog+/wOPOJRIYkLVMIaHhs="; };
+  holochain_0-3-2 = super.callPackage ./holochain/default.nix { version = "0.3.2"; sha256 = "syzrXdVmiqVqvVC1DZQF+rkxLHkTMmTpJz8DylTMyU8="; };
 
   holochain_0-3-x = self.holochain_0-3-1;
   holochain_0-3 = self.createSymlink self.holochain_0-3-x "holochain-0.3";
@@ -139,6 +140,7 @@ self: super: {
 
   hc_0-3-0-beta-dev-47 = super.callPackage ./hc/default.nix { version = "0.3.0-beta-dev.47"; sha256 = "ctkBtXog3+HF2pfpYMiyLhApptwGevD0ve17RSKfttA="; };
   hc_0-3-1 = super.callPackage ./hc/default.nix { version = "0.3.1"; sha256 = "6zccpmpOBisxd3REzEfM58iZgiFZ3H5NvWdtYKrAC3k="; };
+  hc_0-3-2 = super.callPackage ./hc/default.nix { version = "0.3.2"; sha256 = "dD5lKhHR0kPLNXLGl528Oc+4hBdPQWX8MmpMsmfDQs8="; };
 
   hc_0-3-x = self.hc_0-3-1;
   hc_0-3 = self.createSymlink self.hc_0-3-x "hc-0.3";

--- a/holochain-overlay/default.nix
+++ b/holochain-overlay/default.nix
@@ -57,7 +57,7 @@ self: super: {
   holochain_0-3-1 = super.callPackage ./holochain/default.nix { version = "0.3.1"; sha256 = "AkNc8ex/a4Uo8jHXN3M8wFog+/wOPOJRIYkLVMIaHhs="; };
   holochain_0-3-2 = super.callPackage ./holochain/default.nix { version = "0.3.2"; sha256 = "syzrXdVmiqVqvVC1DZQF+rkxLHkTMmTpJz8DylTMyU8="; };
 
-  holochain_0-3-x = self.holochain_0-3-1;
+  holochain_0-3-x = self.holochain_0-3-2;
   holochain_0-3 = self.createSymlink self.holochain_0-3-x "holochain-0.3";
 
   holochain_0-4-0-dev-1 = super.callPackage ./holochain/default.nix { version = "0.4.0-dev.1"; sha256 = "hSu6oidXEMESIxiFvFcnSwI7rjk6iM0XhOS1UJdh7Sw="; };
@@ -142,7 +142,7 @@ self: super: {
   hc_0-3-1 = super.callPackage ./hc/default.nix { version = "0.3.1"; sha256 = "6zccpmpOBisxd3REzEfM58iZgiFZ3H5NvWdtYKrAC3k="; };
   hc_0-3-2 = super.callPackage ./hc/default.nix { version = "0.3.2"; sha256 = "dD5lKhHR0kPLNXLGl528Oc+4hBdPQWX8MmpMsmfDQs8="; };
 
-  hc_0-3-x = self.hc_0-3-1;
+  hc_0-3-x = self.hc_0-3-2;
   hc_0-3 = self.createSymlink self.hc_0-3-x "hc-0.3";
 
   hc_0-4-0-dev-0 = super.callPackage ./hc/default.nix { version = "0.4.0-dev.0"; sha256 = "vQSeazkmySI4sSVy2EGi60LUtv1uyYdg3/TfsKVYei0="; };

--- a/holochain-overlay/default.nix
+++ b/holochain-overlay/default.nix
@@ -10,7 +10,7 @@ self: super: {
   '';
 
   # Helper function to select the appropriate architecture and construct the config
-  selectArchConfig = { system, version, linux_x64, darwin_x64 ? null, darwin_aarch64 ? null, windows_x64 ? null }:
+  selectArchConfig = { system ? builtins.currentSystem, version, linux_x64, darwin_x64 ? null, darwin_aarch64 ? null, windows_x64 ? null }:
     let
       archMap = {
         "x86_64-linux" = { arch = "x86_64-unknown-linux-gnu"; sha256 = linux_x64; };
@@ -127,17 +127,15 @@ self: super: {
 
 
   # Define packages for each version
-  hc_0-4-0-dev-13 = let
-    archConfig = self.selectArchConfig {
-      system = builtins.currentSystem;
+  hc_0-4-0-dev-13 = super.callPackage ./hc/default.nix (
+    self.selectArchConfig {
       version = "0.4.0-dev.13";
       linux_x64 = "/OdBIq8hhePmnQ6FXbt4jD6+4Pm+KIfPHCfd1mgAF8s=";
       darwin_x64 = "iUcUdQak6hCyBzvH7cHvHxuVhs6b14KLQkNnaNfe6mE=";
       darwin_aarch64 = "0000000000000000000000000000000000000000000=";
       windows_x64 = "0000000000000000000000000000000000000000000=";
-    };
-  in super.callPackage ./hc/default.nix archConfig;
-
+    }
+  );
 
   hc_0-4-x = self.hc_0-4-0-dev-13;
   hc_0-4 = self.createSymlink self.hc_0-4-x "hc-0.4";

--- a/holochain-overlay/default.nix
+++ b/holochain-overlay/default.nix
@@ -10,7 +10,7 @@ self: super: {
   '';
 
   # Helper function to select the appropriate architecture and construct the config
-  selectArchConfig = { system ? builtins.currentSystem, version, linux_x64, darwin_x64 ? null, darwin_aarch64 ? null, windows_x64 ? null }:
+  selectArchConfig = { system ? super.system, version, linux_x64, darwin_x64 ? null, darwin_aarch64 ? null, windows_x64 ? null }:
     let
       archMap = {
         "x86_64-linux" = { arch = "x86_64-unknown-linux-gnu"; sha256 = linux_x64; };

--- a/holochain-overlay/default.nix
+++ b/holochain-overlay/default.nix
@@ -89,8 +89,17 @@ self: super: {
       windows_x64 = "c4Tdv/6iUrPlU7SxdxI65Op7w7rb4bLeZkKOv/ZaUZ4=";
     }
   );
+  holochain_0-4-0-dev-15 = super.callPackage ./holochain/default.nix (
+    self.selectArchConfig {
+      version = "0.4.0-dev.15";
+      linux_x64 = "f5Mf3D1ih5W6dWUX5oa5Mgwl8HE1cf2/ITpoDx437Ks=";
+      darwin_x64 = "5DMkJeB7AMGKi5whBmuL+wjAGr20lSxlaPY3ku+QGFE=";
+      darwin_aarch64 = "MhPMgkgFqi7f44BgRqNPV5+be3W7CdnduBdnnxN7YNw=";
+      windows_x64 = "C8Rmebd4J6ekH7uH3kUKxwADRAY/DhomQzxhcW7SbPw=";
+    }
+  );
 
-  holochain_0-4-x = self.holochain_0-4-0-dev-14;
+  holochain_0-4-x = self.holochain_0-4-0-dev-15;
   holochain_0-4 = self.createSymlink self.holochain_0-4-x "holochain-0.4";
 
   holochain_0-x = self.holochain_0-3-x;
@@ -165,8 +174,17 @@ self: super: {
       windows_x64 = "FbN+4e8EGdXUdDtpameBN8iTKmyS6ajBx3ZTIBzsF+g=";
     }
   );
+  hc_0-4-0-dev-15 = super.callPackage ./hc/default.nix (
+    self.selectArchConfig {
+      version = "0.4.0-dev.15";
+      linux_x64 = "YHLzk5Rr5NVL/Aoi+MqL8uA9wR9YQpoCa+htzzVfiZM=";
+      darwin_x64 = "NURYLoNEqTXqDf69mF/vHsOXUXqGgJ0Hy2wDdWA3PZQ=";
+      darwin_aarch64 = "NOO8z4R/0uTBDcHOevczteruWg3SMzmHCK8etXXSGZI=";
+      windows_x64 = "h2k0mnrGPeho1RPR9Lm5Z9rBMqTPWEekVMKZ4gNICys=";
+    }
+  );
 
-  hc_0-4-x = self.hc_0-4-0-dev-14;
+  hc_0-4-x = self.hc_0-4-0-dev-15;
   hc_0-4 = self.createSymlink self.hc_0-4-x "hc-0.4";
 
   hc_0-x = self.hc_0-3-x;

--- a/holochain-overlay/hc/default.nix
+++ b/holochain-overlay/hc/default.nix
@@ -1,21 +1,13 @@
-{ pkgs ? import <nixpkgs> {}, version, sha256, arch ? "x86_64-unknown-linux-gnu" }:
+{ pkgs, version, sha256, arch ? "x86_64-unknown-linux-gnu" }:
 
 with pkgs;
 
 let
-  splitComponents = str: builtins.filter (s: s != "") (builtins.split "-" str);
-  isSubset = set1: set2: builtins.all (x: builtins.elem x set2) set1;
-  isMatch = isSubset
-    (splitComponents (builtins.replaceStrings ["mingw32"] ["windows"] system))
-    (splitComponents arch);
-  warnMismatch =
-    if ! isMatch
-    then builtins.trace
-        "WARNING: Supplying hc version ${version} for ${arch} on a ${system} system; this may not work correctly"
-    else (x: x);
+  name = "hc";
+  warnMismatch = checkCompatibility { inherit version arch name; };
 in
 stdenv.mkDerivation rec {
-  pname = "hc";
+  pname = name;
   inherit version;
 
   src = fetchurl {

--- a/holochain-overlay/hc/default.nix
+++ b/holochain-overlay/hc/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}, version, sha256 }:
+{ pkgs ? import <nixpkgs> {}, version, sha256, arch ? "x86_64-unknown-linux-gnu" }:
 
 with pkgs;
 
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {
-    url = "https://github.com/matthme/holochain-binaries/releases/download/hc-binaries-${version}/hc-v${version}-x86_64-unknown-linux-gnu";
+    url = "https://github.com/matthme/holochain-binaries/releases/download/hc-binaries-${version}/hc-v${version}-${arch}";
     inherit sha256;
   };
 
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Holochain CLI binary downloaded from GitHub releases";
     homepage = "https://github.com/spartan-holochain-counsel/nix-overlay";
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ darwin ++ windows;
   };
 }

--- a/holochain-overlay/hc/default.nix
+++ b/holochain-overlay/hc/default.nix
@@ -2,6 +2,16 @@
 
 with pkgs;
 
+let
+  splitComponents = str: builtins.filter (s: s != "") (builtins.split "-" str);
+  isSubset = set1: set2: builtins.all (x: builtins.elem x set2) set1;
+  isMatch = isSubset ( splitComponents system ) ( splitComponents arch );
+  warnMismatch =
+    if ! isMatch
+    then builtins.trace
+        "WARNING: Supplying hc version ${version} for ${arch} on a ${system} system; this may not work correctly"
+    else (x: x);
+in
 stdenv.mkDerivation rec {
   pname = "hc";
   inherit version;
@@ -17,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = "true"; # Skip the default buildPhase
 
-  installPhase = ''
+  installPhase = warnMismatch ''
     mkdir -p $out/bin
     cp $src $out/bin/hc-${version}
     chmod +x $out/bin/hc-${version}

--- a/holochain-overlay/hc/default.nix
+++ b/holochain-overlay/hc/default.nix
@@ -5,7 +5,9 @@ with pkgs;
 let
   splitComponents = str: builtins.filter (s: s != "") (builtins.split "-" str);
   isSubset = set1: set2: builtins.all (x: builtins.elem x set2) set1;
-  isMatch = isSubset ( splitComponents system ) ( splitComponents arch );
+  isMatch = isSubset
+    (splitComponents (builtins.replaceStrings ["mingw32"] ["windows"] system))
+    (splitComponents arch);
   warnMismatch =
     if ! isMatch
     then builtins.trace

--- a/holochain-overlay/holochain/default.nix
+++ b/holochain-overlay/holochain/default.nix
@@ -1,21 +1,13 @@
-{ pkgs ? import <nixpkgs> {}, version, sha256, arch ? "x86_64-unknown-linux-gnu" }:
+{ pkgs, version, sha256, arch ? "x86_64-unknown-linux-gnu" }:
 
 with pkgs;
 
 let
-  splitComponents = str: builtins.filter (s: s != "") (builtins.split "-" str);
-  isSubset = set1: set2: builtins.all (x: builtins.elem x set2) set1;
-  isMatch = isSubset
-    (splitComponents (builtins.replaceStrings ["mingw32"] ["windows"] system))
-    (splitComponents arch);
-  warnMismatch =
-    if ! isMatch
-    then builtins.trace
-        "WARNING: Supplying holochain version ${version} for ${arch} on a ${system} system; this may not work correctly"
-    else (x: x);
+  name = "holochain";
+  warnMismatch = checkCompatibility { inherit version arch name; };
 in
 stdenv.mkDerivation rec {
-  pname = "holochain";
+  pname = name;
   inherit version;
 
   src = fetchurl {

--- a/holochain-overlay/holochain/default.nix
+++ b/holochain-overlay/holochain/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}, version, sha256 }:
+{ pkgs ? import <nixpkgs> {}, version, sha256, arch ? "x86_64-unknown-linux-gnu" }:
 
 with pkgs;
 
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {
-    url = "https://github.com/matthme/holochain-binaries/releases/download/holochain-binaries-${version}/holochain-v${version}-x86_64-unknown-linux-gnu";
+    url = "https://github.com/matthme/holochain-binaries/releases/download/holochain-binaries-${version}/holochain-v${version}-${arch}";
     inherit sha256;
   };
 
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Holochain binary downloaded from GitHub releases";
     homepage = "https://github.com/spartan-holochain-counsel/nix-overlay";
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ darwin ++ windows;
   };
 }

--- a/holochain-overlay/holochain/default.nix
+++ b/holochain-overlay/holochain/default.nix
@@ -5,7 +5,9 @@ with pkgs;
 let
   splitComponents = str: builtins.filter (s: s != "") (builtins.split "-" str);
   isSubset = set1: set2: builtins.all (x: builtins.elem x set2) set1;
-  isMatch = isSubset ( splitComponents system ) ( splitComponents arch );
+  isMatch = isSubset
+    (splitComponents (builtins.replaceStrings ["mingw32"] ["windows"] system))
+    (splitComponents arch);
   warnMismatch =
     if ! isMatch
     then builtins.trace

--- a/holochain-overlay/holochain/default.nix
+++ b/holochain-overlay/holochain/default.nix
@@ -2,6 +2,16 @@
 
 with pkgs;
 
+let
+  splitComponents = str: builtins.filter (s: s != "") (builtins.split "-" str);
+  isSubset = set1: set2: builtins.all (x: builtins.elem x set2) set1;
+  isMatch = isSubset ( splitComponents system ) ( splitComponents arch );
+  warnMismatch =
+    if ! isMatch
+    then builtins.trace
+        "WARNING: Supplying holochain version ${version} for ${arch} on a ${system} system; this may not work correctly"
+    else (x: x);
+in
 stdenv.mkDerivation rec {
   pname = "holochain";
   inherit version;
@@ -17,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = "true"; # Skip the default buildPhase
 
-  installPhase = ''
+  installPhase = warnMismatch ''
     mkdir -p $out/bin
     cp $src $out/bin/holochain-${version}
     chmod +x $out/bin/holochain-${version}

--- a/holochain-overlay/lair-keystore/default.nix
+++ b/holochain-overlay/lair-keystore/default.nix
@@ -1,21 +1,13 @@
-{ pkgs ? import <nixpkgs> {}, version, sha256, arch ? "x86_64-unknown-linux-gnu" }:
+{ pkgs, version, sha256, arch ? "x86_64-unknown-linux-gnu" }:
 
 with pkgs;
 
 let
-  splitComponents = str: builtins.filter (s: s != "") (builtins.split "-" str);
-  isSubset = set1: set2: builtins.all (x: builtins.elem x set2) set1;
-  isMatch = isSubset
-    (splitComponents (builtins.replaceStrings ["mingw32"] ["windows"] system))
-    (splitComponents arch);
-  warnMismatch =
-    if ! isMatch
-    then builtins.trace
-        "WARNING: Supplying lair-keystore version ${version} for ${arch} on a ${system} system; this may not work correctly"
-    else (x: x);
+  name = "lair-keystore";
+  warnMismatch = checkCompatibility { inherit version arch name; };
 in
 stdenv.mkDerivation rec {
-  pname = "lair-keystore";
+  pname = name;
   inherit version;
 
   src = fetchurl {

--- a/holochain-overlay/lair-keystore/default.nix
+++ b/holochain-overlay/lair-keystore/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}, version, sha256 }:
+{ pkgs ? import <nixpkgs> {}, version, sha256, arch ? "x86_64-unknown-linux-gnu" }:
 
 with pkgs;
 
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {
-    url = "https://github.com/matthme/holochain-binaries/releases/download/lair-binaries-${version}/lair-keystore-v${version}-x86_64-unknown-linux-gnu";
+    url = "https://github.com/matthme/holochain-binaries/releases/download/lair-binaries-${version}/lair-keystore-v${version}-${arch}";
     inherit sha256;
   };
 
@@ -27,6 +27,6 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Lair Keystore binary downloaded from GitHub releases";
     homepage = "https://github.com/spartan-holochain-counsel/nix-overlay";
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ darwin ++ windows;
   };
 }

--- a/holochain-overlay/lair-keystore/default.nix
+++ b/holochain-overlay/lair-keystore/default.nix
@@ -2,6 +2,16 @@
 
 with pkgs;
 
+let
+  splitComponents = str: builtins.filter (s: s != "") (builtins.split "-" str);
+  isSubset = set1: set2: builtins.all (x: builtins.elem x set2) set1;
+  isMatch = isSubset ( splitComponents system ) ( splitComponents arch );
+  warnMismatch =
+    if ! isMatch
+    then builtins.trace
+        "WARNING: Supplying lair-keystore version ${version} for ${arch} on a ${system} system; this may not work correctly"
+    else (x: x);
+in
 stdenv.mkDerivation rec {
   pname = "lair-keystore";
   inherit version;
@@ -17,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = "true"; # Skip the default buildPhase
 
-  installPhase = ''
+  installPhase = warnMismatch ''
     mkdir -p $out/bin
     cp $src $out/bin/lair-keystore-${version}
     chmod +x $out/bin/lair-keystore-${version}

--- a/holochain-overlay/lair-keystore/default.nix
+++ b/holochain-overlay/lair-keystore/default.nix
@@ -5,7 +5,9 @@ with pkgs;
 let
   splitComponents = str: builtins.filter (s: s != "") (builtins.split "-" str);
   isSubset = set1: set2: builtins.all (x: builtins.elem x set2) set1;
-  isMatch = isSubset ( splitComponents system ) ( splitComponents arch );
+  isMatch = isSubset
+    (splitComponents (builtins.replaceStrings ["mingw32"] ["windows"] system))
+    (splitComponents arch);
   warnMismatch =
     if ! isMatch
     then builtins.trace

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -55,6 +55,7 @@ mkShell {
     holochain_0-4-0-dev-12
     holochain_0-4-0-dev-13
     holochain_0-4-0-dev-14
+    holochain_0-4-0-dev-15
 
 
     #
@@ -99,5 +100,6 @@ mkShell {
     hc_0-4-0-dev-12
     hc_0-4-0-dev-13
     hc_0-4-0-dev-14
+    hc_0-4-0-dev-15
   ];
 }

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -1,7 +1,4 @@
-{
-  system ? builtins.currentSystem
-  , pkgs ? import ../default.nix { inherit system; }
-}:
+{ pkgs ? import ../default.nix {} }:
 
 with pkgs;
 
@@ -10,95 +7,95 @@ mkShell {
     #
     # Holochain
     #
-    #holochain
-    #holochain_0
-    #holochain_0-1
-    #holochain_0-2
-    #holochain_0-3
-    #holochain_0-4
+    holochain
+    holochain_0
+    holochain_0-1
+    holochain_0-2
+    holochain_0-3
+    holochain_0-4
 
-    #holochain_0-1-8
+    holochain_0-1-8
 
-    #holochain_0-2-5
-    #holochain_0-2-6-rc-0
-    #holochain_0-2-6
-    #holochain_0-2-7-rc-0
-    #holochain_0-2-7-rc-1
-    #holochain_0-2-7
-    #holochain_0-2-8-rc-0
-    #holochain_0-2-8-rc-1
-    #holochain_0-2-8
+    holochain_0-2-5
+    holochain_0-2-6-rc-0
+    holochain_0-2-6
+    holochain_0-2-7-rc-0
+    holochain_0-2-7-rc-1
+    holochain_0-2-7
+    holochain_0-2-8-rc-0
+    holochain_0-2-8-rc-1
+    holochain_0-2-8
 
-    #holochain_0-3-0-beta-dev-35
-    #holochain_0-3-0-beta-dev-36
-    #holochain_0-3-0-beta-dev-37
-    #holochain_0-3-0-beta-dev-38
-    #holochain_0-3-0-beta-dev-39
-    #holochain_0-3-0-beta-dev-43
-    #holochain_0-3-0-beta-dev-44
-    #holochain_0-3-0-beta-dev-45
-    #holochain_0-3-0-beta-dev-46
-    #holochain_0-3-0-beta-dev-48
-    #holochain_0-3-0
-    #holochain_0-3-1-rc-1
-    #holochain_0-3-1-rc-2
-    #holochain_0-3-1
+    holochain_0-3-0-beta-dev-35
+    holochain_0-3-0-beta-dev-36
+    holochain_0-3-0-beta-dev-37
+    holochain_0-3-0-beta-dev-38
+    holochain_0-3-0-beta-dev-39
+    holochain_0-3-0-beta-dev-43
+    holochain_0-3-0-beta-dev-44
+    holochain_0-3-0-beta-dev-45
+    holochain_0-3-0-beta-dev-46
+    holochain_0-3-0-beta-dev-48
+    holochain_0-3-0
+    holochain_0-3-1-rc-1
+    holochain_0-3-1-rc-2
+    holochain_0-3-1
 
-    #holochain_0-4-0-dev-1
-    #holochain_0-4-0-dev-2
-    #holochain_0-4-0-dev-3
-    #holochain_0-4-0-dev-4
-    #holochain_0-4-0-dev-5
-    #holochain_0-4-0-dev-6
-    #holochain_0-4-0-dev-7
-    #holochain_0-4-0-dev-8
-    #holochain_0-4-0-dev-9
-    #holochain_0-4-0-dev-10
-    #holochain_0-4-0-dev-11
-    #holochain_0-4-0-dev-12
-    #holochain_0-4-0-dev-13
-
-
-    ##
-    ## Lair Keystore
-    ##
-    #lair-keystore
-    #lair-keystore_0
-    #lair-keystore_0-4
-
-    #lair-keystore_0-4-2
-    #lair-keystore_0-4-3
-    #lair-keystore_0-4-4
-    #lair-keystore_0-4-5
+    holochain_0-4-0-dev-1
+    holochain_0-4-0-dev-2
+    holochain_0-4-0-dev-3
+    holochain_0-4-0-dev-4
+    holochain_0-4-0-dev-5
+    holochain_0-4-0-dev-6
+    holochain_0-4-0-dev-7
+    holochain_0-4-0-dev-8
+    holochain_0-4-0-dev-9
+    holochain_0-4-0-dev-10
+    holochain_0-4-0-dev-11
+    holochain_0-4-0-dev-12
+    holochain_0-4-0-dev-13
 
 
-    ##
-    ## Holochain CLI
-    ##
-    #hc
-    #hc_0
-    #hc_0-2
-    #hc_0-3
-    #hc_0-4
+    #
+    # Lair Keystore
+    #
+    lair-keystore
+    lair-keystore_0
+    lair-keystore_0-4
 
-    #hc_0-2-8
+    lair-keystore_0-4-2
+    lair-keystore_0-4-3
+    lair-keystore_0-4-4
+    lair-keystore_0-4-5
 
-    #hc_0-3-0-beta-dev-47
-    #hc_0-3-1
 
-    #hc_0-4-0-dev-0
-    #hc_0-4-0-dev-1
-    #hc_0-4-0-dev-2
-    #hc_0-4-0-dev-3
-    #hc_0-4-0-dev-4
-    #hc_0-4-0-dev-5
-    #hc_0-4-0-dev-6
-    #hc_0-4-0-dev-7
-    #hc_0-4-0-dev-8
-    #hc_0-4-0-dev-9
-    #hc_0-4-0-dev-10
-    #hc_0-4-0-dev-11
-    #hc_0-4-0-dev-12
+    #
+    # Holochain CLI
+    #
+    hc
+    hc_0
+    hc_0-2
+    hc_0-3
+    hc_0-4
+
+    hc_0-2-8
+
+    hc_0-3-0-beta-dev-47
+    hc_0-3-1
+
+    hc_0-4-0-dev-0
+    hc_0-4-0-dev-1
+    hc_0-4-0-dev-2
+    hc_0-4-0-dev-3
+    hc_0-4-0-dev-4
+    hc_0-4-0-dev-5
+    hc_0-4-0-dev-6
+    hc_0-4-0-dev-7
+    hc_0-4-0-dev-8
+    hc_0-4-0-dev-9
+    hc_0-4-0-dev-10
+    hc_0-4-0-dev-11
+    hc_0-4-0-dev-12
     hc_0-4-0-dev-13
   ];
 }

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -54,6 +54,7 @@ mkShell {
     holochain_0-4-0-dev-11
     holochain_0-4-0-dev-12
     holochain_0-4-0-dev-13
+    holochain_0-4-0-dev-14
 
 
     #
@@ -97,5 +98,6 @@ mkShell {
     hc_0-4-0-dev-11
     hc_0-4-0-dev-12
     hc_0-4-0-dev-13
+    hc_0-4-0-dev-14
   ];
 }

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -40,6 +40,7 @@ mkShell {
     holochain_0-3-1-rc-1
     holochain_0-3-1-rc-2
     holochain_0-3-1
+    holochain_0-3-2
 
     holochain_0-4-0-dev-1
     holochain_0-4-0-dev-2
@@ -84,6 +85,7 @@ mkShell {
 
     hc_0-3-0-beta-dev-47
     hc_0-3-1
+    hc_0-3-2
 
     hc_0-4-0-dev-0
     hc_0-4-0-dev-1

--- a/tests/shell.nix
+++ b/tests/shell.nix
@@ -1,4 +1,7 @@
-{ pkgs ? import ../default.nix {} }:
+{
+  system ? builtins.currentSystem
+  , pkgs ? import ../default.nix { inherit system; }
+}:
 
 with pkgs;
 
@@ -7,95 +10,95 @@ mkShell {
     #
     # Holochain
     #
-    holochain
-    holochain_0
-    holochain_0-1
-    holochain_0-2
-    holochain_0-3
-    holochain_0-4
+    #holochain
+    #holochain_0
+    #holochain_0-1
+    #holochain_0-2
+    #holochain_0-3
+    #holochain_0-4
 
-    holochain_0-1-8
+    #holochain_0-1-8
 
-    holochain_0-2-5
-    holochain_0-2-6-rc-0
-    holochain_0-2-6
-    holochain_0-2-7-rc-0
-    holochain_0-2-7-rc-1
-    holochain_0-2-7
-    holochain_0-2-8-rc-0
-    holochain_0-2-8-rc-1
-    holochain_0-2-8
+    #holochain_0-2-5
+    #holochain_0-2-6-rc-0
+    #holochain_0-2-6
+    #holochain_0-2-7-rc-0
+    #holochain_0-2-7-rc-1
+    #holochain_0-2-7
+    #holochain_0-2-8-rc-0
+    #holochain_0-2-8-rc-1
+    #holochain_0-2-8
 
-    holochain_0-3-0-beta-dev-35
-    holochain_0-3-0-beta-dev-36
-    holochain_0-3-0-beta-dev-37
-    holochain_0-3-0-beta-dev-38
-    holochain_0-3-0-beta-dev-39
-    holochain_0-3-0-beta-dev-43
-    holochain_0-3-0-beta-dev-44
-    holochain_0-3-0-beta-dev-45
-    holochain_0-3-0-beta-dev-46
-    holochain_0-3-0-beta-dev-48
-    holochain_0-3-0
-    holochain_0-3-1-rc-1
-    holochain_0-3-1-rc-2
-    holochain_0-3-1
+    #holochain_0-3-0-beta-dev-35
+    #holochain_0-3-0-beta-dev-36
+    #holochain_0-3-0-beta-dev-37
+    #holochain_0-3-0-beta-dev-38
+    #holochain_0-3-0-beta-dev-39
+    #holochain_0-3-0-beta-dev-43
+    #holochain_0-3-0-beta-dev-44
+    #holochain_0-3-0-beta-dev-45
+    #holochain_0-3-0-beta-dev-46
+    #holochain_0-3-0-beta-dev-48
+    #holochain_0-3-0
+    #holochain_0-3-1-rc-1
+    #holochain_0-3-1-rc-2
+    #holochain_0-3-1
 
-    holochain_0-4-0-dev-1
-    holochain_0-4-0-dev-2
-    holochain_0-4-0-dev-3
-    holochain_0-4-0-dev-4
-    holochain_0-4-0-dev-5
-    holochain_0-4-0-dev-6
-    holochain_0-4-0-dev-7
-    holochain_0-4-0-dev-8
-    holochain_0-4-0-dev-9
-    holochain_0-4-0-dev-10
-    holochain_0-4-0-dev-11
-    holochain_0-4-0-dev-12
-    holochain_0-4-0-dev-13
-
-
-    #
-    # Lair Keystore
-    #
-    lair-keystore
-    lair-keystore_0
-    lair-keystore_0-4
-
-    lair-keystore_0-4-2
-    lair-keystore_0-4-3
-    lair-keystore_0-4-4
-    lair-keystore_0-4-5
+    #holochain_0-4-0-dev-1
+    #holochain_0-4-0-dev-2
+    #holochain_0-4-0-dev-3
+    #holochain_0-4-0-dev-4
+    #holochain_0-4-0-dev-5
+    #holochain_0-4-0-dev-6
+    #holochain_0-4-0-dev-7
+    #holochain_0-4-0-dev-8
+    #holochain_0-4-0-dev-9
+    #holochain_0-4-0-dev-10
+    #holochain_0-4-0-dev-11
+    #holochain_0-4-0-dev-12
+    #holochain_0-4-0-dev-13
 
 
-    #
-    # Holochain CLI
-    #
-    hc
-    hc_0
-    hc_0-2
-    hc_0-3
-    hc_0-4
+    ##
+    ## Lair Keystore
+    ##
+    #lair-keystore
+    #lair-keystore_0
+    #lair-keystore_0-4
 
-    hc_0-2-8
+    #lair-keystore_0-4-2
+    #lair-keystore_0-4-3
+    #lair-keystore_0-4-4
+    #lair-keystore_0-4-5
 
-    hc_0-3-0-beta-dev-47
-    hc_0-3-1
 
-    hc_0-4-0-dev-0
-    hc_0-4-0-dev-1
-    hc_0-4-0-dev-2
-    hc_0-4-0-dev-3
-    hc_0-4-0-dev-4
-    hc_0-4-0-dev-5
-    hc_0-4-0-dev-6
-    hc_0-4-0-dev-7
-    hc_0-4-0-dev-8
-    hc_0-4-0-dev-9
-    hc_0-4-0-dev-10
-    hc_0-4-0-dev-11
-    hc_0-4-0-dev-12
+    ##
+    ## Holochain CLI
+    ##
+    #hc
+    #hc_0
+    #hc_0-2
+    #hc_0-3
+    #hc_0-4
+
+    #hc_0-2-8
+
+    #hc_0-3-0-beta-dev-47
+    #hc_0-3-1
+
+    #hc_0-4-0-dev-0
+    #hc_0-4-0-dev-1
+    #hc_0-4-0-dev-2
+    #hc_0-4-0-dev-3
+    #hc_0-4-0-dev-4
+    #hc_0-4-0-dev-5
+    #hc_0-4-0-dev-6
+    #hc_0-4-0-dev-7
+    #hc_0-4-0-dev-8
+    #hc_0-4-0-dev-9
+    #hc_0-4-0-dev-10
+    #hc_0-4-0-dev-11
+    #hc_0-4-0-dev-12
     hc_0-4-0-dev-13
   ];
 }


### PR DESCRIPTION
This is a Work-In-Progress toward supporting other architectures.

Presently, it seems to support x86_64-apple-darwin for hc_0-4-0-dev-13.

- If you try other versions (with only x86_64-unknown-linux-gnu), they actually install the Linux target on macOS, so that's not right yet.
- It's quite a large set of sha256 hashes for each version, but I don't see any way to address that.
  - Perhaps only support the latest version(s) on all architectures?